### PR TITLE
From v2.3, allow JSON formatted token response

### DIFF
--- a/lib/Facebook/OpenGraph.pm
+++ b/lib/Facebook/OpenGraph.pm
@@ -269,9 +269,7 @@ sub _get_token {
     # It, however, returnes no "expires" parameter on some edge cases.
     # e.g. Your app requests manage_pages permission.
     # https://developers.facebook.com/bugs/597779113651383/
-    my $res_content = $response->content;
-
-    if ($res_content =~ m/\A { .+ } \z/xms) {
+    if ($response->is_api_version_eq_or_later_than('v2.3')) {
         # As of v2.3, to be compliant with RFC 6749, response is JSON formatted
         # as described below.
         # {"access_token": <TOKEN>, "token_type":<TYPE>, "expires_in":<TIME>}
@@ -279,6 +277,7 @@ sub _get_token {
         return $response->as_hashref;
     }
 
+    my $res_content = $response->content;
     my $token_ref = +{ URI->new("?$res_content")->query_form };
     croak "can't get access_token properly: $res_content"
         unless $token_ref->{access_token};

--- a/lib/Facebook/OpenGraph.pm
+++ b/lib/Facebook/OpenGraph.pm
@@ -270,8 +270,17 @@ sub _get_token {
     # e.g. Your app requests manage_pages permission.
     # https://developers.facebook.com/bugs/597779113651383/
     my $res_content = $response->content;
-    my $token_ref = +{ URI->new('?'.$res_content)->query_form };
-    croak qq{can't get access_token properly: $res_content}
+
+    if ($res_content =~ m/\A { .+ } \z/xms) {
+        # As of v2.3, to be compliant with RFC 6749, response is JSON formatted
+        # as described below.
+        # {"access_token": <TOKEN>, "token_type":<TYPE>, "expires_in":<TIME>}
+        # https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/v2.3#confirm
+        return $response->as_hashref;
+    }
+
+    my $token_ref = +{ URI->new("?$res_content")->query_form };
+    croak "can't get access_token properly: $res_content"
         unless $token_ref->{access_token};
 
     return $token_ref;
@@ -1062,29 +1071,31 @@ on your callback endpoint which is specified on C<eredirect_uri>. Give the
 returning access token to C<set_access_token()> and you can act on behalf of
 the user.
 
-FYI: I<expires> is B<NOT> returned on some edge cases. The detail and schenario
-should be found at L<https://developers.facebook.com/bugs/597779113651383/>.
+FYI: I<expires> or I<expires_in> is B<NOT> returned on some edge cases. The
+detail and reproductive scenario should be found at
+L<https://developers.facebook.com/bugs/597779113651383/>.
 
   # On OAuth callback page which you specified on $fb->redirect_uri.
   my $req          = Plack::Request->new($env);
-  my $token_ref    = $fb->get_user_token_by_code($req->query_param('code'))
+  my $token_ref    = $fb->get_user_token_by_code($req->query_param('code'));
   my $access_token = $token_ref->{access_token};
-  my $expires      = $token_ref->{expires};
+  my $expires      = $token_ref->{expires}; # named expires_in as of v2.3
 
 =head3 C<< $fb->get_user_token_by_cookie($cookie_value) >>
 
 Obtain user access token based on the cookie value that is set by JS SDK.
 Cookie name should be determined with C<js_cookie_name()>.
 
-FYI: I<expires> is B<NOT> returned on some edge cases. The detail and schenario
-should be found at L<https://developers.facebook.com/bugs/597779113651383/>.
+FYI: I<expires> or I<expires_in> is B<NOT> returned on some edge cases. The
+detail and reproductive schenario should be found at
+L<https://developers.facebook.com/bugs/597779113651383/>.
 
   if (my $cookie = $c->req->cookie( $fb->js_cookie_name )) {
     # User is not logged in yet, but cookie is set by JS SDK on previous visit.
     my $token_ref = $fb->get_user_token_by_cookie($cookie);
     # {
     #     "access_token" : "new_token_string_qwerty",
-    #     "expires" : 5752
+    #     "expires" : 5752 # named expires_in as of v2.3
     # };
   }
   else {
@@ -1097,12 +1108,14 @@ Exchange short lived access token for long lived one. Short lived tokens are
 ones that you obtain with C<get_user_token_by_code()>. Usually long lived
 tokens live about 60 days while short lived ones live about 2 hours.
 
-FYI: I<expires> is B<NOT> returned on some edge cases. The detail and schenario
-should be found at L<https://developers.facebook.com/bugs/597779113651383/>.
+FYI: I<expires> or I<expires_in> is B<NOT> returned on some edge cases. The
+detail and reproductive schenario should be found at
+L<https://developers.facebook.com/bugs/597779113651383/>.
 
   my $extended_token_ref = $fb->exchange_token($token_ref->{access_token});
   my $access_token       = $extended_token_ref->{access_token};
   my $expires            = $extended_token_ref->{expires};
+                           # named expires_in as of v2.3
 
 If you loved how old offline_access permission worked and are looking for a
 substitute you might want to try this.

--- a/lib/Facebook/OpenGraph/Response.pm
+++ b/lib/Facebook/OpenGraph/Response.pm
@@ -31,6 +31,31 @@ sub req_content { shift->{req_content}  }
 sub json        { shift->{json}         }
 sub etag        { shift->header('etag') }
 
+sub api_version {
+    my $self = shift;
+    return $self->header('facebook-api-version');
+}
+
+sub is_api_version_eq_or_later_than {
+    my ($self, $comparing_version) = @_;
+    croak 'comparing version is not given.' unless $comparing_version;
+
+    my $decimal_comparing_version = ( $comparing_version =~ s/\A v //rx  +  0 );
+    my $decimal_response_version  = ( $self->api_version =~ s/\A v //rx  +  0 );
+
+    return $decimal_comparing_version <= $decimal_response_version;
+}
+
+sub is_api_version_eq_or_older_than {
+    my ($self, $comparing_version) = @_;
+    croak 'comparing version is not given.' unless $comparing_version;
+
+    my $decimal_comparing_version = ( $comparing_version =~ s/\A v //rx  +  0 );
+    my $decimal_response_version  = ( $self->api_version =~ s/\A v //rx  +  0 );
+
+    return $decimal_comparing_version >= $decimal_response_version;
+}
+
 sub header {
     my ($self, $key) = @_;
 
@@ -223,6 +248,23 @@ Returns specified header field value.
 
   my $res  = $fb->request('GET', 'go.hagiwara');
   my $etag = $res->header('etag'); # "a376a57cb3a4bd3a3c6a53fca06b0fd5badee50b"
+
+=head3 C<< $res->api_version >>
+
+By checking facebook-api-version header value, it returns API version that
+current API call actually experienced. This may differ from the one you
+specified. See
+L<https://developers.facebook.com/docs/apps/changelog#v2_1>
+
+=head3 C<< $res->is_api_version_eq_or_older_than($comparing_version) >>
+
+Compare $comparing_version with the facebook-api-version header value and
+returns TRUE when facebook-api-version is older than the given version.
+
+=head3 C<< $res->is_api_version_eq_or_later_than($comparing_version) >>
+
+Compare $comparing_version with the facebook-api-version header value and
+returns TRUE when facebook-api-version is newer than the given version.
 
 =head3 C<< $res->is_success >>
 

--- a/lib/Facebook/OpenGraph/Response.pm
+++ b/lib/Facebook/OpenGraph/Response.pm
@@ -40,20 +40,20 @@ sub is_api_version_eq_or_later_than {
     my ($self, $comparing_version) = @_;
     croak 'comparing version is not given.' unless $comparing_version;
 
-    my $decimal_comparing_version = ( $comparing_version =~ s/\A v //rx  +  0 );
-    my $decimal_response_version  = ( $self->api_version =~ s/\A v //rx  +  0 );
+    (my $decimal_comparing_version = $comparing_version) =~ s/\A v //x;
+    (my $decimal_response_version  = $self->api_version) =~ s/\A v //x;
 
-    return $decimal_comparing_version <= $decimal_response_version;
+    return ($decimal_comparing_version + 0) <= ($decimal_response_version + 0);
 }
 
 sub is_api_version_eq_or_older_than {
     my ($self, $comparing_version) = @_;
     croak 'comparing version is not given.' unless $comparing_version;
 
-    my $decimal_comparing_version = ( $comparing_version =~ s/\A v //rx  +  0 );
-    my $decimal_response_version  = ( $self->api_version =~ s/\A v //rx  +  0 );
+    (my $decimal_comparing_version = $comparing_version) =~ s/\A v //x;
+    (my $decimal_response_version  = $self->api_version) =~ s/\A v //x;
 
-    return $decimal_comparing_version >= $decimal_response_version;
+    return ($decimal_comparing_version + 0) >= ($decimal_response_version + 0);
 }
 
 sub header {

--- a/t/002_retrieve/01_get_app_token.t
+++ b/t/002_retrieve/01_get_app_token.t
@@ -33,7 +33,10 @@ subtest 'get' => sub {
                 1,
                 200,
                 'OK',
-                ['Content-Type' => 'text/plain; charset=UTF-8'],
+                [
+                    'Content-Type'         => 'text/plain; charset=UTF-8',
+                    'facebook-api-version' => 'v2.0'
+                ],
                 'access_token=123456789|SSSeFWB-0EQ0qyipMdmNpJJJJjk',
             );
         },

--- a/t/002_retrieve/02_get_user_token.t
+++ b/t/002_retrieve/02_get_user_token.t
@@ -77,10 +77,11 @@ subtest 'using v2.3' => sub {
     # {"access_token": <TOKEN>, "token_type":<TYPE>, "expires_in":<TIME>}.
     # We made this update to be compliant with section 5.1 of RFC 6749.
 
-    my $code    = 'XXXXXXXXXXXXXXXXXXXXXX';
-    my $app_id  = 123456789;
-    my $token   = '123456789XXXXXXXXXXX';
-    my $expires = 5183814;
+    my $code       = 'XXXXXXXXXXXXXXXXXXXXXX';
+    my $app_id     = 123456789;
+    my $token      = '123456789XXXXXXXXXXX';
+    my $expires    = 5183814;
+    my $token_type = 'bearer';
 
     $Mock_furl_http->mock(
         request => sub {
@@ -113,7 +114,7 @@ subtest 'using v2.3' => sub {
                 encode_json(+{
                     access_token => $token,
                     expires_in   => $expires,
-                    token_type   => 'Bearer',
+                    token_type   => $token_type,
                 })
             );
         },
@@ -133,7 +134,7 @@ subtest 'using v2.3' => sub {
         +{
             access_token => $token,
             expires_in   => $expires,
-            token_type   => 'Bearer',
+            token_type   => $token_type,
         },
         'token',
     );

--- a/t/002_retrieve/02_get_user_token.t
+++ b/t/002_retrieve/02_get_user_token.t
@@ -40,7 +40,10 @@ subtest 'success' => sub {
                 1,
                 200,
                 'OK',
-                ['Content-Type' => 'text/plain; charset=UTF-8'],
+                [
+                    'Content-Type'         => 'text/plain; charset=UTF-8',
+                    'facebook-api-version' => 'v2.2',
+                ],
                 sprintf('access_token=%s&expires=%d', $token, $expires),
             );
         },
@@ -110,7 +113,10 @@ subtest 'using v2.3' => sub {
                 1,
                 200,
                 'OK',
-                ['Content-Type' => 'text/plain; charset=UTF-8'],
+                [
+                    'Content-Type'         => 'text/plain; charset=UTF-8',
+                    'facebook-api-version' => 'v2.3',
+                ],
                 encode_json(+{
                     access_token => $token,
                     expires_in   => $expires,

--- a/t/002_retrieve/02_get_user_token.t
+++ b/t/002_retrieve/02_get_user_token.t
@@ -4,6 +4,7 @@ use Test::More;
 use Test::Exception;
 use Test::Mock::Furl;
 use Facebook::OpenGraph;
+use JSON 2 qw(encode_json);
 
 subtest 'success' => sub {
 
@@ -34,7 +35,7 @@ subtest 'success' => sub {
             );
             is $args{method}, 'GET', 'HTTP GET method';
             is $args{content}, '', 'content';
-    
+
             return (
                 1,
                 200,
@@ -63,7 +64,81 @@ subtest 'success' => sub {
         'token',
     );
     is $fb->access_token, undef, 'no access_token is set';
-    $fb->set_access_token($token_ref->{access_token});        
+    $fb->set_access_token($token_ref->{access_token});
+    is $fb->access_token, $token, 'acess token is set';
+
+};
+
+subtest 'using v2.3' => sub {
+    # https://developers.facebook.com/docs/apps/changelog#v2_3_changes
+    # he response format of https://www.facebook.com/v2.3/oauth/access_token
+    # returned when you exchange a code for an access_token now return valid
+    # JSON instead of being URL encoded. The new format of this response is
+    # {"access_token": <TOKEN>, "token_type":<TYPE>, "expires_in":<TIME>}.
+    # We made this update to be compliant with section 5.1 of RFC 6749.
+
+    my $code    = 'XXXXXXXXXXXXXXXXXXXXXX';
+    my $app_id  = 123456789;
+    my $token   = '123456789XXXXXXXXXXX';
+    my $expires = 5183814;
+
+    $Mock_furl_http->mock(
+        request => sub {
+            my ($mock, %args) = @_;
+            is_deeply $args{headers}, [], 'no particular header';
+            my $uri = $args{url};
+            is $uri->scheme, 'https', 'scheme';
+            is $uri->host, 'graph.facebook.com', 'host';
+            is $uri->path, '/oauth/access_token', 'path';
+            is_deeply(
+                +{
+                    $uri->query_form,
+                },
+                +{
+                    client_secret => 'secret',
+                    client_id     => $app_id,
+                    code          => $code,
+                    redirect_uri  => 'http://sample.com/auth_cb',
+                },
+                'query',
+            );
+            is $args{method}, 'GET', 'HTTP GET method';
+            is $args{content}, '', 'content';
+
+            return (
+                1,
+                200,
+                'OK',
+                ['Content-Type' => 'text/plain; charset=UTF-8'],
+                encode_json(+{
+                    access_token => $token,
+                    expires_in   => $expires,
+                    token_type   => 'Bearer',
+                })
+            );
+        },
+    );
+
+    # Redirect_uri should be exactly the same as the one
+    # that you used on $fb->auth_uri
+    my $fb = Facebook::OpenGraph->new(+{
+        app_id       => $app_id,
+        secret       => 'secret',
+        redirect_uri => 'http://sample.com/auth_cb',
+    });
+    my $token_ref = $fb->get_user_token_by_code($code);
+
+    is_deeply(
+        $token_ref,
+        +{
+            access_token => $token,
+            expires_in   => $expires,
+            token_type   => 'Bearer',
+        },
+        'token',
+    );
+    is $fb->access_token, undef, 'no access_token is set';
+    $fb->set_access_token($token_ref->{access_token});
     is $fb->access_token, $token, 'acess token is set';
 
 };

--- a/t/002_retrieve/14_exchange_token.t
+++ b/t/002_retrieve/14_exchange_token.t
@@ -34,13 +34,16 @@ subtest 'success' => sub {
             );
             is $args{method}, 'GET', 'HTTP GET method';
             is $args{content}, '', 'content';
-            
+
             # returns long-lived access token
             return (
                 1,
                 200,
                 'OK',
-                ['Content-Type' => 'text/plain; charset=UTF-8'],
+                [
+                    'Content-Type'         => 'text/plain; charset=UTF-8',
+                    'facebook-api-version' => 'v2.1',
+                ],
                 sprintf(
                     'access_token=%s&expires=%d',
                     $long_lived_token,
@@ -49,7 +52,7 @@ subtest 'success' => sub {
             );
         },
     );
-    
+
     my $fb = Facebook::OpenGraph->new(+{
         app_id => $app_id,
         secret => 'secret',
@@ -97,7 +100,7 @@ subtest 'w/o app_id' => sub {
         qr/app_id and secret must be set /,
         'app_id is not set',
     );
-    
+
 };
 
 done_testing;

--- a/t/002_retrieve/15_get_user_token_by_cookie.t
+++ b/t/002_retrieve/15_get_user_token_by_cookie.t
@@ -48,17 +48,20 @@ subtest 'success' => sub {
             );
             is $args{method}, 'GET', 'HTTP GET method';
             is $args{content}, '', 'content';
-    
+
             return (
                 1,
                 200,
                 'OK',
-                ['Content-Type' => 'text/plain; charset=UTF-8'],
+                [
+                    'Content-Type'         => 'text/plain; charset=UTF-8',
+                    'facebook-api-version' => 'v2.1',
+                ],
                 sprintf('access_token=%s&expires=%d', $token, $expires),
             );
         },
     );
-    
+
     my $fb = Facebook::OpenGraph->new(+{
         app_id => $app_id,
         secret => $secret,
@@ -148,17 +151,20 @@ subtest 'expires is not returned from FB' => sub {
             );
             is $args{method}, 'GET', 'HTTP GET method';
             is $args{content}, '', 'content';
-    
+
             return (
                 1,
                 200,
                 'OK',
-                ['Content-Type' => 'text/plain; charset=UTF-8'],
+                [
+                    'Content-Type'         => 'text/plain; charset=UTF-8',
+                    'facebook-api-version' => 'v2.1',
+                ],
                 sprintf('access_token=%s', $token),
             );
         },
     );
-    
+
     my $fb = Facebook::OpenGraph->new(+{
         app_id => $app_id,
         secret => $secret,

--- a/t/004_response/01_basic.t
+++ b/t/004_response/01_basic.t
@@ -32,7 +32,9 @@ subtest 'accessor' => sub {
         'connection',
         'keep-alive',
         'content-length',
-        '185'
+        '185',
+        'facebook-api-version',
+        'v2.3',
     ];
     my $req_headers = qq{GET /go.hagiwara HTTP/1.1\n}
                     . qq{Connection: keep-alive\n}
@@ -57,8 +59,61 @@ subtest 'accessor' => sub {
     is($res->req_content, '');
     is($res->content, $content);
     is($res->etag, '"a376a57cb3a4bd3a3c6a53fca06b0fd5badee50b"');
+    is($res->api_version, 'v2.3');
     isa_ok($res->json, 'JSON');
     is_deeply($res->headers, $headers);
+};
+
+subtest 'is_api_version_eq_or_older_than' => sub {
+    my $headers = [
+        'facebook-api-version',
+        'v2.3',
+    ];
+    my $req_headers = qq{GET /go.hagiwara HTTP/1.1\n}
+                    . qq{Connection: keep-alive\n}
+                    . qq{User-Agent: Facebook::OpenGraph/1.13\n}
+                    . qq{Content-Length: 0\n}
+                    . qq{Host: graph.facebook.com\n}
+                    . qq{\n};
+    my $content = '{"id":"12345"}';
+
+    my $res = Facebook::OpenGraph::Response->new(+{
+        code        => 200,
+        message     => 'OK',
+        headers     => $headers,
+        req_headers => $req_headers,
+        req_content => '',
+        content     => $content,
+    });
+
+    ok($res->is_api_version_eq_or_older_than('v2.3'));
+    ok($res->is_api_version_eq_or_older_than('v2.4'));
+};
+
+subtest 'is_api_version_eq_or_later_than' => sub {
+    my $headers = [
+        'facebook-api-version',
+        'v2.3',
+    ];
+    my $req_headers = qq{GET /go.hagiwara HTTP/1.1\n}
+                    . qq{Connection: keep-alive\n}
+                    . qq{User-Agent: Facebook::OpenGraph/1.13\n}
+                    . qq{Content-Length: 0\n}
+                    . qq{Host: graph.facebook.com\n}
+                    . qq{\n};
+    my $content = '{"id":"12345"}';
+
+    my $res = Facebook::OpenGraph::Response->new(+{
+        code        => 200,
+        message     => 'OK',
+        headers     => $headers,
+        req_headers => $req_headers,
+        req_content => '',
+        content     => $content,
+    });
+
+    ok($res->is_api_version_eq_or_later_than('v2.3'));
+    ok($res->is_api_version_eq_or_later_than('v2.2'));
 };
 
 done_testing;


### PR DESCRIPTION
The [changelog](https://developers.facebook.com/docs/apps/upgrading#v22tov23) states that /oauth/access_token endpoint is now returning JSON formatted string.
> Manually Build a Login Flow
> If you build your own Login flow, there is an update to the OAuth code exchange that now conforms to the latest OAuth RFC spec. See details in the changelog entry, see Facebook Platform Changelog, API version 2.3.

The detailed spec. is described at [Confirming identity](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/v2.3#confirm).
> The response you will receive from this endpoint will be returned in JSON format and, if successful, is
>  {“access_token”: &lt;access-token&gt;, “token_type”:&lt;type&gt;, “expires_in”:&lt;seconds-til-expiration&gt;}
> If it is not successful, you will receive an explanatory error message.

Remember they used to return the seconds till expiration with a name of "expires", but now it is named "expires_in".