### PR TITLE
[WIP] Remove FQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ including:
 - Acquiring user, app and/or page token and refreshing user token for
 long lived one.
 - Batch Request
-- FQL
-- FQL with Multi-Query
 - Field Expansion
 - Etag
 - Wall Posting with Photo or Video
@@ -506,44 +504,6 @@ create [Facebook::OpenGraph::Response](https://metacpan.org/pod/Facebook::OpenGr
 You can specify access token for each query within a single batch request.
 See [https://developers.facebook.com/docs/graph-api/making-multiple-requests/](https://developers.facebook.com/docs/graph-api/making-multiple-requests/)
 for detail.
-
-### `$fb->fql($fql_query)`
-
-Alias to `request()` that optimizes query parameter for FQL query and sends
-`GET` request.
-
-    my $res = $fb->fql('SELECT display_name FROM application WHERE app_id = 12345');
-    #{
-    #    data => [{
-    #        display_name => 'app',
-    #    }],
-    #}
-
-### `$fb->bulk_fql(\%fql_queries)`
-
-Alias to `fql()` to request multiple FQL query at once.
-
-    my $res = $fb->bulk_fql(+{
-        'all friends' => 'SELECT uid2 FROM friend WHERE uid1 = me()',
-        'my name'     => 'SELECT name FROM user WHERE uid = me()',
-    });
-    #{
-    #    data => [
-    #        {
-    #            fql_result_set => [
-    #                {uid2 => 12345},
-    #                {uid2 => 67890},
-    #            ],
-    #            name => 'all friends',
-    #        },
-    #        {
-    #            fql_result_set => [
-    #                name => 'Michael Corleone'
-    #            ],
-    #            name => 'my name',
-    #        },
-    #    ],
-    #}
 
 ### `$fb->delete($path, \%param)`
 

--- a/lib/Facebook/OpenGraph.pm
+++ b/lib/Facebook/OpenGraph.pm
@@ -392,22 +392,6 @@ sub batch_fast {
     return \@responses;
 }
 
-# Facebook Query Language (FQL) Overview
-# https://developers.facebook.com/docs/technical-guides/fql/
-sub fql {
-    my $self  = shift;
-    my $query = shift;
-    return $self->get('/fql', +{q => $query}, @_);
-}
-
-# Facebook Query Language (FQL) Overview: Multi-query
-# https://developers.facebook.com/docs/technical-guides/fql/#multi
-sub bulk_fql {
-    my $self  = shift;
-    my $batch = shift;
-    return $self->fql($self->json->encode($batch), @_);
-}
-
 sub request {
     my ($self, $method, $uri, $param_ref, $headers) = @_;
 
@@ -747,10 +731,6 @@ including:
 long lived one.
 
 =item * Batch Request
-
-=item * FQL
-
-=item * FQL with Multi-Query
 
 =item * Field Expansion
 
@@ -1211,44 +1191,6 @@ create L<Facebook::OpenGraph::Response> to handle each response.
 You can specify access token for each query within a single batch request.
 See L<https://developers.facebook.com/docs/graph-api/making-multiple-requests/>
 for detail.
-
-=head3 C<< $fb->fql($fql_query) >>
-
-Alias to C<request()> that optimizes query parameter for FQL query and sends
-C<GET> request.
-
-  my $res = $fb->fql('SELECT display_name FROM application WHERE app_id = 12345');
-  #{
-  #    data => [{
-  #        display_name => 'app',
-  #    }],
-  #}
-
-=head3 C<< $fb->bulk_fql(\%fql_queries) >>
-
-Alias to C<fql()> to request multiple FQL query at once.
-
-  my $res = $fb->bulk_fql(+{
-      'all friends' => 'SELECT uid2 FROM friend WHERE uid1 = me()',
-      'my name'     => 'SELECT name FROM user WHERE uid = me()',
-  });
-  #{
-  #    data => [
-  #        {
-  #            fql_result_set => [
-  #                {uid2 => 12345},
-  #                {uid2 => 67890},
-  #            ],
-  #            name => 'all friends',
-  #        },
-  #        {
-  #            fql_result_set => [
-  #                name => 'Michael Corleone'
-  #            ],
-  #            name => 'my name',
-  #        },
-  #    ],
-  #}
 
 =head3 C<< $fb->delete($path, \%param) >>
 

--- a/t/002_retrieve/08_fql.t
+++ b/t/002_retrieve/08_fql.t
@@ -6,6 +6,8 @@ use URI;
 use JSON 2 qw/encode_json/;
 use Facebook::OpenGraph;
 
+plan skip_all => "FQL is no longer supported by Graph API";
+
 subtest 'user' => sub {
 
     my $app_id = 127497087322461;
@@ -30,7 +32,7 @@ subtest 'user' => sub {
                 },
                 'args'
             );
-    
+
             return (
                 1,
                 200,
@@ -47,9 +49,8 @@ subtest 'user' => sub {
 
     my $fb = Facebook::OpenGraph->new;
     my $res = $fb->fql($query);
-    
+
     is_deeply $res->{data}, [$datum_ref], 'data';
-    
 };
 
 done_testing;

--- a/t/002_retrieve/09_bulk_fql.t
+++ b/t/002_retrieve/09_bulk_fql.t
@@ -5,6 +5,8 @@ use Test::Mock::Furl;
 use JSON 2 qw(decode_json encode_json);
 use Facebook::OpenGraph;
 
+plan skip_all => "FQL is no longer supported by Graph API";
+
 subtest 'multi query w/out dependencies' => sub {
 
     my $val = [
@@ -44,7 +46,7 @@ subtest 'multi query w/out dependencies' => sub {
             is_deeply $args{headers}, [], 'no particular header';
             is $args{content}, '', 'content';
             is $args{method}, 'GET', 'HTTP GET method';
-    
+
             my $uri = $args{url};
             is $uri->scheme, 'https', 'scheme';
             is $uri->path, '/fql', 'path';
@@ -57,7 +59,7 @@ subtest 'multi query w/out dependencies' => sub {
                 },
                 'query parameter',
             );
-    
+
             return (
                 1,
                 200,


### PR DESCRIPTION
[Graph API v2.1](https://developers.facebook.com/docs/apps/changelog#v2_1) removed its support for FQL and current oldest supported version is *v2.2*. It's time to say bye to good ol' FQL.