### PR TITLE
Fix version comparisions in Facebook::Opengraph::Response

### DIFF
--- a/lib/Facebook/OpenGraph/Response.pm
+++ b/lib/Facebook/OpenGraph/Response.pm
@@ -46,7 +46,7 @@ sub is_api_version_eq_or_later_than {
     (my $response_major, my $response_minor)
         = $self->api_version =~ m/ (\d+) \. (\d+ )/x;
 
-    return $comp_major <= $response_major && $comp_minor <= $response_minor;
+    return $comp_major < $response_major || ($comp_major == $response_major && $comp_minor <= $response_minor);
 }
 
 sub is_api_version_eq_or_older_than {
@@ -59,7 +59,7 @@ sub is_api_version_eq_or_older_than {
     (my $response_major, my $response_minor)
         = $self->api_version =~ m/ (\d+) \. (\d+ )/x;
 
-    return $response_major <= $comp_major && $response_minor <= $comp_minor;
+    return $response_major < $comp_major || ($response_major == $comp_major && $response_minor <= $comp_minor);
 }
 
 sub header {

--- a/t/004_response/01_basic.t
+++ b/t/004_response/01_basic.t
@@ -91,6 +91,7 @@ subtest 'is_api_version_eq_or_older_than' => sub {
     ok($res->is_api_version_eq_or_older_than('v2.3'));
     ok($res->is_api_version_eq_or_older_than('v2.4'));
     ok($res->is_api_version_eq_or_older_than('v2.10'));
+    ok($res->is_api_version_eq_or_older_than('v3.1'));
     ok($res->is_api_version_eq_or_older_than('v3.3'));
     ok($res->is_api_version_eq_or_older_than('v3.4'));
 };
@@ -119,6 +120,7 @@ subtest 'is_api_version_eq_or_later_than' => sub {
 
     ok($res->is_api_version_eq_or_later_than('v1.2'));
     ok($res->is_api_version_eq_or_later_than('v1.3'));
+    ok($res->is_api_version_eq_or_later_than('v1.4'));
     ok($res->is_api_version_eq_or_later_than('v2.2'));
     ok($res->is_api_version_eq_or_later_than('v2.3'));
     ok(!$res->is_api_version_eq_or_later_than('v2.10'));


### PR DESCRIPTION
When using Facebook API version 3.2, the comparision in
`Facebook::OpenGraph->_get_token` that tests if the response is 2.3 is later
failed.

This happens because `is_api_version_eq_or_later_than` compares the API versions
like this:

```
$comp_major <= $response_major && $comp_minor <= $response_minor;
```

However while `$comp_major` is less than `$response_major`, the same does not hold
for the minor versions. The minor version only needs to be less than, iff the
major versions are the same.

This patch fixes this issue in both `is_api_version_eq_or_later_than` and
`is_api_version_eq_or_older_than`, and adds tests to verify that it works as
expected.