### PR TITLE
Support resumable video upload

### DIFF
--- a/lib/Facebook/OpenGraph.pm
+++ b/lib/Facebook/OpenGraph.pm
@@ -451,7 +451,7 @@ sub request {
 
     my $content = q{};
     if ($method eq 'POST') {
-        if ($param_ref->{source} || $param_ref->{file}) {
+        if ($param_ref->{source} || $param_ref->{file} || $param_ref->{upload_phase} ) {
             # post image or video file
 
             # https://developers.facebook.com/docs/reference/api/video/
@@ -576,13 +576,16 @@ sub prep_param {
         $param_ref->{permissions} = ref $perms ? join q{,}, @$perms : $perms;
     }
 
-    # Source and file parameter contains file path.
+    # Source, file and video_file_chunk parameter contains file path.
     # It must be an array ref to work with HTTP::Request::Common.
     if (my $path = $param_ref->{source}) {
         $param_ref->{source} = ref $path ? $path : [$path];
     }
     if (my $path = $param_ref->{file}) {
         $param_ref->{file} = ref $path ? $path : [$path];
+    }
+    if (my $path = $param_ref->{video_file_chunk}) {
+        $param_ref->{video_file_chunk} = ref $path ? $path : [$path];
     }
 
     # use Field Expansion

--- a/t/003_publish/02_post_photo.t
+++ b/t/003_publish/02_post_photo.t
@@ -24,7 +24,7 @@ subtest 'post photo' => sub {
                     ],
                 }
             );
-    
+
             return (
                 1,
                 200,

--- a/t/003_publish/03_post_movie.t
+++ b/t/003_publish/03_post_movie.t
@@ -5,7 +5,7 @@ use Test::Mock::Furl;
 use JSON 2 qw(encode_json);
 use Facebook::OpenGraph;
 
-subtest 'post movie' => sub {
+subtest 'post movie with Non-Resumable Uploading API' => sub {
 
     $Mock_furl_http->mock(
         request => sub {
@@ -25,7 +25,7 @@ subtest 'post movie' => sub {
                 },
                 'args'
             );
-    
+
             return (
                 1,
                 200,
@@ -53,6 +53,138 @@ subtest 'post movie' => sub {
     );
 
     is_deeply $response, +{ id => 111111111 }, 'response';
+
+};
+
+subtest 'start uploading with Resumable Uploading API' => sub {
+
+    $Mock_furl_http->mock(
+        request => sub {
+            my ($mock, %args) = @_;
+
+            # The document does not clearly state what Content-Type to be used
+            # on upload_phase of "start" and "finish."
+            # https://developers.facebook.com/docs/graph-api/resumable-upload-api/
+            # However the example with curl uses -F instead of -d.
+            ok $args{content}, 'content';
+            ok $args{content} =~ m/Content-Disposition: form-data; name="upload_phase"/s, 'upload_phase';
+            ok $args{content} =~ m/Content-Disposition: form-data; name="file_size"/s, 'file_size';
+            delete $args{content};
+
+            is_deeply(
+                \%args,
+                +{
+                    url     => 'https://graph-video.facebook.com/me/videos',
+                    method  => 'POST',
+                    headers => [
+                        'Authorization'  => 'OAuth 12345qwerty',
+                        'Content-Length' => 151,
+                        'Content-Type'   => 'multipart/form-data; boundary=xYzZY',
+                    ],
+                },
+                'args'
+            );
+
+            return (
+                1,
+                200,
+                'OK',
+                ['Content-Type' => 'text/javascript; charset=UTF-8'],
+                encode_json(+{
+                    upload_session_id => "1564747013773438",
+                    video_id          => "1564747010440105",
+                    start_offset      => "0",
+                    end_offset        => "52428800",
+                }),
+            );
+
+        },
+    );
+
+    my $fb = Facebook::OpenGraph->new(+{
+        app_id       => 12345678,
+        access_token => '12345qwerty',
+    });
+    my $response = $fb->publish(
+        '/me/videos',
+        +{
+            upload_phase => 'start',
+            file_size    => 288828,
+        }
+    );
+
+    is_deeply $response,
+              +{
+                upload_session_id => "1564747013773438",
+                video_id          => "1564747010440105",
+                start_offset      => "0",
+                end_offset        => "52428800",
+              },
+              'response';
+
+};
+
+subtest 'transfer chunked file content with Resumable' => sub {
+
+    $Mock_furl_http->mock(
+        request => sub {
+            my ($mock, %args) = @_;
+
+            ok $args{content}, 'content';
+            ok $args{content} =~ m/Content-Disposition: form-data; name="upload_phase"/s, 'upload_phase';
+            ok $args{content} =~ m/Content-Disposition: form-data; name="start_offset"/s, 'start_offset';
+            ok $args{content} =~ m/Content-Disposition: form-data; name="upload_session_id"/s, 'upload_session_id';
+            ok $args{content} =~ m/Content-Disposition: form-data; name="video_file_chunk"/s, 'video_file_chunk';
+            delete $args{content};
+
+            is_deeply(
+                \%args,
+                +{
+                    url     => 'https://graph-video.facebook.com/me/videos',
+                    method  => 'POST',
+                    headers => [
+                        'Authorization'  => 'OAuth 12345qwerty',
+                        'Content-Length' => 289193, # Original size of 289105 + misc form data
+                        'Content-Type'   => 'multipart/form-data; boundary=xYzZY',
+                    ],
+                },
+                'args'
+            );
+
+            return (
+                1,
+                200,
+                'OK',
+                ['Content-Type' => 'text/javascript; charset=UTF-8'],
+                encode_json(+{
+                    start_offset => "52428800",
+                    end_offset   => "104857601",
+                }),
+            );
+
+        },
+    );
+
+    my $fb = Facebook::OpenGraph->new(+{
+        app_id       => 12345678,
+        access_token => '12345qwerty',
+    });
+    my $response = $fb->publish(
+        '/me/videos',
+        +{
+            upload_phase      => 'transfer',
+            start_offset      => 0,
+            upload_session_id => 1564747013773438,
+            video_file_chunk  => './t/resource/IMG_6753.MOV',
+        }
+    );
+
+    is_deeply $response,
+              +{
+                start_offset => "52428800",
+                end_offset   => "104857601",
+              },
+              'response';
 
 };
 


### PR DESCRIPTION
This solves #22 by handling extra fields for [Resumable Uploading](https://developers.facebook.com/docs/graph-api/video-uploads#resumable).
The document does not clearly state what Content-Type to be used on "start" and "finish" where actual file data is absent, but the example code with curl command uses `-F` rather than `-d` so this uses `multipart/form-data` for all requests with `upload_phase` parameter.